### PR TITLE
feat(visualization): add 3D mesh plotting with sphere background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /docs/Manifest*.toml
 /docs/build/
 /docs/superpowers/
+/.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,11 @@ julia --project=. -e 'include("test/test_latlon_geometry.jl")'
 
 # Aqua code quality checks
 julia --project=. -e 'using Pkg; Pkg.test()'  # Aqua runs first in runtests.jl
+
+# Visualization (requires adding a Makie backend to your environment)
+using CairoMakie  # or GLMakie for interactive 3D
+fig = plot_mesh(grid; view=Symbol("3d"))
+save("mesh.png", fig)
 ```
 
 ## Design Principles
@@ -29,6 +34,9 @@ src/
 ├── ManifoldMeshes.jl    # Module entry, exports, includes
 ├── traits.jl            # TopologyStyle (IsGrid/IsMesh), AbstractLocation (NodeLoc/CellLoc/EdgeLoc)
 ├── interface.jl         # AbstractManifoldMesh + 15 function stubs
+├── visualization/
+│   ├── mesh_data.jl     # Data extraction: node_points, edge_segments, cell_polygons
+│   └── plotting.jl      # plot_mesh, plot_mesh_filled (requires Makie at runtime)
 └── sphere/
     └── latlon.jl        # LatLonGrid implementation
 ```
@@ -56,7 +64,7 @@ src/
 - Every public function must have a test
 - Always test edge cases: polar cells, periodic boundaries, degenerate diagonals
 - Fundamental sanity checks: `Σ cell_volume = 4πR²`
-- Test files: `test_traits.jl`, `test_latlon_{construction,geometry,connectivity,normals,edge_cases}.jl`, `test_performance.jl`
+- Test files: `test_traits.jl`, `test_latlon_{construction,geometry,connectivity,normals,edge_cases}.jl`, `test_performance.jl`, `test_visualization_data.jl`, `test_visualization_smoke.jl`
 
 ## Dependencies
 
@@ -69,6 +77,7 @@ src/
 - Full-sphere grids have **no boundary** — `boundary_nodes` and `boundary_edges` return empty vectors
 - Node at lon=0 and lon=360 are the **same physical point** with different linear IDs
 - `edge_outward_normal` returns `NamedTuple{:base_point, :normal}` (tangent space semantics), not a plain vector
+- `plot_mesh` requires Makie to be loaded **before** calling — run `using CairoMakie` or `using GLMakie` first
 
 ## Commit Convention
 

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "d2a7aed9-80bb-46a9-9a56-e170a93cc177"
 version = "0.1.1"
 
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Manifolds = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
@@ -23,9 +24,8 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "CairoMakie"]
+test = ["Aqua", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,28 +3,28 @@ uuid = "d2a7aed9-80bb-46a9-9a56-e170a93cc177"
 version = "0.1.1"
 
 [deps]
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Manifolds = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 ManifoldsBase = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
-GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Aqua = "0.8"
+CairoMakie = "0.12"
 GeometryBasics = "0.4"
 LinearAlgebra = "1.10"
+Makie = "0.22"
 Manifolds = "0.11"
 ManifoldsBase = "2.3"
-Makie = "0.22"
-CairoMakie = "0.12"
 StaticArrays = "1.9"
 Test = "1.10"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/src/ManifoldMeshes.jl
+++ b/src/ManifoldMeshes.jl
@@ -21,5 +21,12 @@ export slerp, node_points, edge_segments, cell_polygons
 
 include("sphere/latlon.jl")
 include("visualization/mesh_data.jl")
+include("visualization/plotting.jl")
+
+for sym in [:plot_mesh, :plot_mesh_filled]
+    @eval ManifoldMeshes const $sym = VisualizationPlotting.$sym
+end
+
+export plot_mesh, plot_mesh_filled
 
 end # module

--- a/src/ManifoldMeshes.jl
+++ b/src/ManifoldMeshes.jl
@@ -5,6 +5,7 @@ using ManifoldsBase
 using StaticArrays
 using LinearAlgebra
 using GeometryBasics: Point3f
+using CairoMakie
 
 include("traits.jl")
 include("interface.jl")

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -73,8 +73,6 @@ function _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
     fig = M.Figure(; size = figsize)
     ax = M.LScene(fig[1, 1]; show_axis = false)
 
-    _add_sphere_background!(ax, M; R = _get_radius(g))
-
     if show_edges
         segs = edge_segments(g; n_arc_points)
         for seg in segs
@@ -86,13 +84,13 @@ function _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
 
     if show_nodes
         pts = node_points(g)
-        M.meshscatter!(ax, pts; color = :orangered, markersize = 5, kwargs...)
+        M.meshscatter!(ax, pts; color = :orangered, markersize = 0.03, kwargs...)
     end
 
     if show_cell_ids
         for cid in 1:num_cells(g)
             c = cell_centroid(g, cid)
-            M.text!(ax, [M.Point3f(Float32.(c))],
+            M.text!(ax, [Point3f(Float32.(c))],
                 text = ["$cid"], fontsize = 6, color = :black, kwargs...)
         end
     end
@@ -100,7 +98,7 @@ function _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
     if show_node_ids
         for nid in 1:num_nodes(g)
             c = node_coordinates(g, nid)
-            M.text!(ax, [M.Point3f(Float32.(c))],
+            M.text!(ax, [Point3f(Float32.(c))],
                 text = ["$nid"], fontsize = 5, color = :gray, kwargs...)
         end
     end
@@ -116,8 +114,6 @@ function _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs.
     fig = M.Figure(; size = figsize)
     ax = M.LScene(fig[1, 1]; show_axis = false)
 
-    _add_sphere_background!(ax, M; R = _get_radius(g))
-
     polys = cell_polygons(g; n_arc_points)
     for (i, poly) in enumerate(polys)
         if length(poly) >= 3
@@ -125,7 +121,7 @@ function _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs.
             color = color_by === nothing ? :lightblue : color_by(i)
             for k in 2:(length(poly) - 1)
                 M.mesh!(ax, [center, poly[k], poly[k + 1]];
-                    color = color, transparency = true, kwargs...)
+                    color = color, transparency = true, shading = M.NoShading, kwargs...)
             end
         end
     end
@@ -253,7 +249,7 @@ function _add_sphere_background!(ax, M; R = 1.0)
     ye = [R * sin(phiv) * sin(thetav) for thetav in theta, phiv in phi]
     ze = [R * cos(thetav) for thetav in theta, phiv in phi]
     M.surface!(ax, xe, ye, ze;
-        color = (:lightgray, 0.15),
+        color = M.RGBA(0.8, 0.8, 0.8, 0.1),
         transparency = true,
         shading = M.NoShading)
 end

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -1,5 +1,6 @@
 module VisualizationPlotting
 
+using CairoMakie
 using ..ManifoldMeshes
 using ..ManifoldMeshes: node_points, edge_segments, cell_polygons
 using GeometryBasics: Point3f
@@ -120,10 +121,7 @@ end
 # -- Helpers --
 
 function _require_makie()
-    if !isdefined(Main, :Makie)
-        error("Makie is required for visualization. Run: `using CairoMakie` or `using GLMakie` before calling plot_mesh.")
-    end
-    return Main.Makie
+    return CairoMakie
 end
 
 function _get_radius(g::AbstractManifoldMesh)

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -1,0 +1,259 @@
+module VisualizationPlotting
+
+using ..ManifoldMeshes
+using ..ManifoldMeshes: node_points, edge_segments, cell_polygons
+using GeometryBasics: Point3f
+
+"""
+    plot_mesh(g::AbstractManifoldMesh;
+              show_nodes::Bool = false,
+              show_edges::Bool = true,
+              show_cell_ids::Bool = false,
+              show_node_ids::Bool = false,
+              view::Symbol = Symbol("3d"),
+              projection::Symbol = :equirectangular,
+              n_arc_points::Int = 20,
+              figsize::Tuple{Int,Int} = (800, 600),
+              kwargs...) -> Figure
+
+Plot mesh wireframe. Returns a Makie `Figure`.
+"""
+function plot_mesh(g::AbstractManifoldMesh;
+                   show_nodes::Bool = false,
+                   show_edges::Bool = true,
+                   show_cell_ids::Bool = false,
+                   show_node_ids::Bool = false,
+                   view::Symbol = Symbol("3d"),
+                   projection::Symbol = :equirectangular,
+                   n_arc_points::Int = 20,
+                   figsize::Tuple{Int,Int} = (800, 600),
+                   kwargs...)
+    view == Symbol("3d") ? _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
+                                  show_node_ids, n_arc_points, figsize, kwargs...) :
+    view == Symbol("2d") ? _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
+                                  show_node_ids, n_arc_points, projection,
+                                  figsize, kwargs...) :
+    error("Unsupported view: $view. Use Symbol(\"3d\") or Symbol(\"2d\").")
+end
+
+"""
+    plot_mesh_filled(g::AbstractManifoldMesh;
+                     show_edges::Bool = true,
+                     color_by = nothing,
+                     kwargs...) -> Figure
+
+Plot filled cell polygons with optional wireframe overlay. Returns a Makie `Figure`.
+
+# Keywords
+- `color_by = nothing`: callable taking cell index (`Int`) and returning a Makie color,
+  or `nothing` for default `lightblue`.
+"""
+function plot_mesh_filled(g::AbstractManifoldMesh;
+                          show_edges::Bool = true,
+                          color_by = nothing,
+                          view::Symbol = Symbol("3d"),
+                          n_arc_points::Int = 20,
+                          figsize::Tuple{Int,Int} = (800, 600),
+                          kwargs...)
+    view == Symbol("3d") ? _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs...) :
+    view == Symbol("2d") ? _plot_filled_2d(g; show_edges, color_by, n_arc_points, figsize, kwargs...) :
+    error("Unsupported view: $view. Use Symbol(\"3d\") or Symbol(\"2d\").")
+end
+
+# -- 3D wireframe --
+
+function _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
+                        show_node_ids, n_arc_points, figsize, kwargs...)
+    M = _require_makie()
+
+    fig = M.Figure(; size=figsize)
+    ax = M.LScene(fig[1, 1]; show_axis=false)
+
+    _add_sphere_background!(ax, M; R=_get_radius(g))
+
+    if show_edges
+        segs = edge_segments(g; n_arc_points)
+        for seg in segs
+            if length(seg) > 1
+                M.lines!(ax, seg; color=:steelblue, linewidth=0.5, kwargs...)
+            end
+        end
+    end
+
+    if show_nodes
+        pts = node_points(g)
+        M.meshscatter!(ax, pts; color=:orangered, markersize=5, kwargs...)
+    end
+
+    if show_cell_ids
+        for cid in 1:num_cells(g)
+            c = cell_centroid(g, cid)
+            M.text!(ax, [M.Point3f(Float32.(c))],
+                    text=["$cid"], fontsize=6, color=:black, kwargs...)
+        end
+    end
+
+    if show_node_ids
+        for nid in 1:num_nodes(g)
+            c = node_coordinates(g, nid)
+            M.text!(ax, [M.Point3f(Float32.(c))],
+                    text=["$nid"], fontsize=5, color=:gray, kwargs...)
+        end
+    end
+
+    return fig
+end
+
+# -- 3D filled --
+
+function _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs...)
+    M = _require_makie()
+
+    fig = M.Figure(; size=figsize)
+    ax = M.LScene(fig[1, 1]; show_axis=false)
+
+    _add_sphere_background!(ax, M; R=_get_radius(g))
+
+    polys = cell_polygons(g; n_arc_points)
+    for (i, poly) in enumerate(polys)
+        if length(poly) >= 3
+            center = poly[1]
+            color = color_by === nothing ? :lightblue : color_by(i)
+            for k in 2:length(poly)-1
+                M.mesh!(ax, [center, poly[k], poly[k+1]];
+                        color=color, transparency=true, kwargs...)
+            end
+        end
+    end
+
+    if show_edges
+        segs = edge_segments(g; n_arc_points)
+        for seg in segs
+            if length(seg) > 1
+                M.lines!(ax, seg; color=:steelblue, linewidth=0.5, kwargs...)
+            end
+        end
+    end
+
+    return fig
+end
+
+# -- 2D wireframe (equirectangular) --
+
+function _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
+                        show_node_ids, n_arc_points, projection,
+                        figsize, kwargs...)
+    projection == :equirectangular || error("Only :equirectangular projection is supported")
+    M = _require_makie()
+
+    fig = M.Figure(; size=figsize)
+    ax = M.Axis(fig[1, 1];
+                xlabel="Longitude (deg)", ylabel="Latitude (deg)",
+                title="Mesh (equirectangular)")
+
+    if show_edges
+        segs = edge_segments(g; n_arc_points)
+        for seg in segs
+            if length(seg) > 1
+                lons = [_lon_from_xyz(p) for p in seg]
+                lats = [_lat_from_xyz(p) for p in seg]
+                M.lines!(ax, lons, lats; color=:steelblue, linewidth=0.5, kwargs...)
+            end
+        end
+    end
+
+    if show_nodes
+        pts = node_points(g)
+        xs = [_lon_from_xyz(p) for p in pts]
+        ys = [_lat_from_xyz(p) for p in pts]
+        M.scatter!(ax, xs, ys; color=:orangered, markersize=5, kwargs...)
+    end
+
+    if show_cell_ids
+        for cid in 1:num_cells(g)
+            c = cell_centroid(g, cid)
+            lon = _lon_from_xyz(Point3f(Float32.(c)))
+            lat = _lat_from_xyz(Point3f(Float32.(c)))
+            M.text!(ax, [lon], [lat]; text=["$cid"], fontsize=6, kwargs...)
+        end
+    end
+
+    if show_node_ids
+        for nid in 1:num_nodes(g)
+            c = node_coordinates(g, nid)
+            lon = _lon_from_xyz(Point3f(Float32.(c)))
+            lat = _lat_from_xyz(Point3f(Float32.(c)))
+            M.text!(ax, [lon], [lat]; text=["$nid"], fontsize=5, color=:gray, kwargs...)
+        end
+    end
+
+    return fig
+end
+
+# -- 2D filled --
+
+function _plot_filled_2d(g; show_edges, color_by, n_arc_points, figsize, kwargs...)
+    M = _require_makie()
+
+    fig = M.Figure(; size=figsize)
+    ax = M.Axis(fig[1, 1];
+                xlabel="Longitude (deg)", ylabel="Latitude (deg)",
+                title="Mesh (equirectangular)")
+
+    polys = cell_polygons(g; n_arc_points)
+    for poly in polys
+        if length(poly) >= 3
+            lons = [_lon_from_xyz(p) for p in poly]
+            lats = [_lat_from_xyz(p) for p in poly]
+            push!(lons, lons[1])
+            push!(lats, lats[1])
+            M.lines!(ax, lons, lats; color=:lightblue, linewidth=1, kwargs...)
+            M.poly!(ax, lons, lats; color=:lightblue, strokewidth=0, kwargs...)
+        end
+    end
+
+    if show_edges
+        segs = edge_segments(g; n_arc_points)
+        for seg in segs
+            if length(seg) > 1
+                lons = [_lon_from_xyz(p) for p in seg]
+                lats = [_lat_from_xyz(p) for p in seg]
+                M.lines!(ax, lons, lats; color=:steelblue, linewidth=0.5, kwargs...)
+            end
+        end
+    end
+
+    return fig
+end
+
+# -- Helpers --
+
+function _require_makie()
+    if !isdefined(Main, :Makie)
+        error("Makie is required for visualization. Run: `using CairoMakie` or `using GLMakie` before calling plot_mesh.")
+    end
+    return Main.Makie
+end
+
+function _get_radius(g::AbstractManifoldMesh)
+    c = node_coordinates(g, 1)
+    return sqrt(sum(c.^2))
+end
+
+function _add_sphere_background!(ax, M; R=1.0)
+    n = 64
+    theta = LinRange(0, pi, n)
+    phi = LinRange(-pi, pi, 2n)
+    xe = [R * cos(phiv) * sin(thetav) for thetav in theta, phiv in phi]
+    ye = [R * sin(phiv) * sin(thetav) for thetav in theta, phiv in phi]
+    ze = [R * cos(thetav) for thetav in theta, phiv in phi]
+    M.surface!(ax, xe, ye, ze;
+              color=(:lightgray, 0.15),
+              transparency=true,
+              shading=M.NoShading)
+end
+
+_lon_from_xyz(p) = rad2deg(atan(p[2], p[1]))
+_lat_from_xyz(p) = rad2deg(asin(clamp(p[3] / sqrt(sum(p.^2)), -1, 1)))
+
+end  # module VisualizationPlotting

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -19,20 +19,22 @@ using GeometryBasics: Point3f
 Plot mesh wireframe. Returns a Makie `Figure`.
 """
 function plot_mesh(g::AbstractManifoldMesh;
-                   show_nodes::Bool = false,
-                   show_edges::Bool = true,
-                   show_cell_ids::Bool = false,
-                   show_node_ids::Bool = false,
-                   view::Symbol = Symbol("3d"),
-                   projection::Symbol = :equirectangular,
-                   n_arc_points::Int = 20,
-                   figsize::Tuple{Int,Int} = (800, 600),
-                   kwargs...)
-    view == Symbol("3d") ? _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
-                                  show_node_ids, n_arc_points, figsize, kwargs...) :
-    view == Symbol("2d") ? _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
-                                  show_node_ids, n_arc_points, projection,
-                                  figsize, kwargs...) :
+        show_nodes::Bool = false,
+        show_edges::Bool = true,
+        show_cell_ids::Bool = false,
+        show_node_ids::Bool = false,
+        view::Symbol = Symbol("3d"),
+        projection::Symbol = :equirectangular,
+        n_arc_points::Int = 20,
+        figsize::Tuple{Int, Int} = (800, 600),
+        kwargs...)
+    view == Symbol("3d") ?
+    _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
+        show_node_ids, n_arc_points, figsize, kwargs...) :
+    view == Symbol("2d") ?
+    _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
+        show_node_ids, n_arc_points, projection,
+        figsize, kwargs...) :
     error("Unsupported view: $view. Use Symbol(\"3d\") or Symbol(\"2d\").")
 end
 
@@ -49,47 +51,49 @@ Plot filled cell polygons with optional wireframe overlay. Returns a Makie `Figu
   or `nothing` for default `lightblue`.
 """
 function plot_mesh_filled(g::AbstractManifoldMesh;
-                          show_edges::Bool = true,
-                          color_by = nothing,
-                          view::Symbol = Symbol("3d"),
-                          n_arc_points::Int = 20,
-                          figsize::Tuple{Int,Int} = (800, 600),
-                          kwargs...)
-    view == Symbol("3d") ? _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs...) :
-    view == Symbol("2d") ? _plot_filled_2d(g; show_edges, color_by, n_arc_points, figsize, kwargs...) :
+        show_edges::Bool = true,
+        color_by = nothing,
+        view::Symbol = Symbol("3d"),
+        n_arc_points::Int = 20,
+        figsize::Tuple{Int, Int} = (800, 600),
+        kwargs...)
+    view == Symbol("3d") ?
+    _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs...) :
+    view == Symbol("2d") ?
+    _plot_filled_2d(g; show_edges, color_by, n_arc_points, figsize, kwargs...) :
     error("Unsupported view: $view. Use Symbol(\"3d\") or Symbol(\"2d\").")
 end
 
 # -- 3D wireframe --
 
 function _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
-                        show_node_ids, n_arc_points, figsize, kwargs...)
+        show_node_ids, n_arc_points, figsize, kwargs...)
     M = _require_makie()
 
-    fig = M.Figure(; size=figsize)
-    ax = M.LScene(fig[1, 1]; show_axis=false)
+    fig = M.Figure(; size = figsize)
+    ax = M.LScene(fig[1, 1]; show_axis = false)
 
-    _add_sphere_background!(ax, M; R=_get_radius(g))
+    _add_sphere_background!(ax, M; R = _get_radius(g))
 
     if show_edges
         segs = edge_segments(g; n_arc_points)
         for seg in segs
             if length(seg) > 1
-                M.lines!(ax, seg; color=:steelblue, linewidth=0.5, kwargs...)
+                M.lines!(ax, seg; color = :steelblue, linewidth = 0.5, kwargs...)
             end
         end
     end
 
     if show_nodes
         pts = node_points(g)
-        M.meshscatter!(ax, pts; color=:orangered, markersize=5, kwargs...)
+        M.meshscatter!(ax, pts; color = :orangered, markersize = 5, kwargs...)
     end
 
     if show_cell_ids
         for cid in 1:num_cells(g)
             c = cell_centroid(g, cid)
             M.text!(ax, [M.Point3f(Float32.(c))],
-                    text=["$cid"], fontsize=6, color=:black, kwargs...)
+                text = ["$cid"], fontsize = 6, color = :black, kwargs...)
         end
     end
 
@@ -97,7 +101,7 @@ function _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
         for nid in 1:num_nodes(g)
             c = node_coordinates(g, nid)
             M.text!(ax, [M.Point3f(Float32.(c))],
-                    text=["$nid"], fontsize=5, color=:gray, kwargs...)
+                text = ["$nid"], fontsize = 5, color = :gray, kwargs...)
         end
     end
 
@@ -109,19 +113,19 @@ end
 function _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs...)
     M = _require_makie()
 
-    fig = M.Figure(; size=figsize)
-    ax = M.LScene(fig[1, 1]; show_axis=false)
+    fig = M.Figure(; size = figsize)
+    ax = M.LScene(fig[1, 1]; show_axis = false)
 
-    _add_sphere_background!(ax, M; R=_get_radius(g))
+    _add_sphere_background!(ax, M; R = _get_radius(g))
 
     polys = cell_polygons(g; n_arc_points)
     for (i, poly) in enumerate(polys)
         if length(poly) >= 3
             center = poly[1]
             color = color_by === nothing ? :lightblue : color_by(i)
-            for k in 2:length(poly)-1
-                M.mesh!(ax, [center, poly[k], poly[k+1]];
-                        color=color, transparency=true, kwargs...)
+            for k in 2:(length(poly) - 1)
+                M.mesh!(ax, [center, poly[k], poly[k + 1]];
+                    color = color, transparency = true, kwargs...)
             end
         end
     end
@@ -130,7 +134,7 @@ function _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs.
         segs = edge_segments(g; n_arc_points)
         for seg in segs
             if length(seg) > 1
-                M.lines!(ax, seg; color=:steelblue, linewidth=0.5, kwargs...)
+                M.lines!(ax, seg; color = :steelblue, linewidth = 0.5, kwargs...)
             end
         end
     end
@@ -141,15 +145,15 @@ end
 # -- 2D wireframe (equirectangular) --
 
 function _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
-                        show_node_ids, n_arc_points, projection,
-                        figsize, kwargs...)
+        show_node_ids, n_arc_points, projection,
+        figsize, kwargs...)
     projection == :equirectangular || error("Only :equirectangular projection is supported")
     M = _require_makie()
 
-    fig = M.Figure(; size=figsize)
+    fig = M.Figure(; size = figsize)
     ax = M.Axis(fig[1, 1];
-                xlabel="Longitude (deg)", ylabel="Latitude (deg)",
-                title="Mesh (equirectangular)")
+        xlabel = "Longitude (deg)", ylabel = "Latitude (deg)",
+        title = "Mesh (equirectangular)")
 
     if show_edges
         segs = edge_segments(g; n_arc_points)
@@ -157,7 +161,7 @@ function _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
             if length(seg) > 1
                 lons = [_lon_from_xyz(p) for p in seg]
                 lats = [_lat_from_xyz(p) for p in seg]
-                M.lines!(ax, lons, lats; color=:steelblue, linewidth=0.5, kwargs...)
+                M.lines!(ax, lons, lats; color = :steelblue, linewidth = 0.5, kwargs...)
             end
         end
     end
@@ -166,7 +170,7 @@ function _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
         pts = node_points(g)
         xs = [_lon_from_xyz(p) for p in pts]
         ys = [_lat_from_xyz(p) for p in pts]
-        M.scatter!(ax, xs, ys; color=:orangered, markersize=5, kwargs...)
+        M.scatter!(ax, xs, ys; color = :orangered, markersize = 5, kwargs...)
     end
 
     if show_cell_ids
@@ -174,7 +178,7 @@ function _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
             c = cell_centroid(g, cid)
             lon = _lon_from_xyz(Point3f(Float32.(c)))
             lat = _lat_from_xyz(Point3f(Float32.(c)))
-            M.text!(ax, [lon], [lat]; text=["$cid"], fontsize=6, kwargs...)
+            M.text!(ax, [lon], [lat]; text = ["$cid"], fontsize = 6, kwargs...)
         end
     end
 
@@ -183,7 +187,8 @@ function _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
             c = node_coordinates(g, nid)
             lon = _lon_from_xyz(Point3f(Float32.(c)))
             lat = _lat_from_xyz(Point3f(Float32.(c)))
-            M.text!(ax, [lon], [lat]; text=["$nid"], fontsize=5, color=:gray, kwargs...)
+            M.text!(
+                ax, [lon], [lat]; text = ["$nid"], fontsize = 5, color = :gray, kwargs...)
         end
     end
 
@@ -195,10 +200,10 @@ end
 function _plot_filled_2d(g; show_edges, color_by, n_arc_points, figsize, kwargs...)
     M = _require_makie()
 
-    fig = M.Figure(; size=figsize)
+    fig = M.Figure(; size = figsize)
     ax = M.Axis(fig[1, 1];
-                xlabel="Longitude (deg)", ylabel="Latitude (deg)",
-                title="Mesh (equirectangular)")
+        xlabel = "Longitude (deg)", ylabel = "Latitude (deg)",
+        title = "Mesh (equirectangular)")
 
     polys = cell_polygons(g; n_arc_points)
     for poly in polys
@@ -207,8 +212,8 @@ function _plot_filled_2d(g; show_edges, color_by, n_arc_points, figsize, kwargs.
             lats = [_lat_from_xyz(p) for p in poly]
             push!(lons, lons[1])
             push!(lats, lats[1])
-            M.lines!(ax, lons, lats; color=:lightblue, linewidth=1, kwargs...)
-            M.poly!(ax, lons, lats; color=:lightblue, strokewidth=0, kwargs...)
+            M.lines!(ax, lons, lats; color = :lightblue, linewidth = 1, kwargs...)
+            M.poly!(ax, lons, lats; color = :lightblue, strokewidth = 0, kwargs...)
         end
     end
 
@@ -218,7 +223,7 @@ function _plot_filled_2d(g; show_edges, color_by, n_arc_points, figsize, kwargs.
             if length(seg) > 1
                 lons = [_lon_from_xyz(p) for p in seg]
                 lats = [_lat_from_xyz(p) for p in seg]
-                M.lines!(ax, lons, lats; color=:steelblue, linewidth=0.5, kwargs...)
+                M.lines!(ax, lons, lats; color = :steelblue, linewidth = 0.5, kwargs...)
             end
         end
     end
@@ -237,10 +242,10 @@ end
 
 function _get_radius(g::AbstractManifoldMesh)
     c = node_coordinates(g, 1)
-    return sqrt(sum(c.^2))
+    return sqrt(sum(c .^ 2))
 end
 
-function _add_sphere_background!(ax, M; R=1.0)
+function _add_sphere_background!(ax, M; R = 1.0)
     n = 64
     theta = LinRange(0, pi, n)
     phi = LinRange(-pi, pi, 2n)
@@ -248,12 +253,12 @@ function _add_sphere_background!(ax, M; R=1.0)
     ye = [R * sin(phiv) * sin(thetav) for thetav in theta, phiv in phi]
     ze = [R * cos(thetav) for thetav in theta, phiv in phi]
     M.surface!(ax, xe, ye, ze;
-              color=(:lightgray, 0.15),
-              transparency=true,
-              shading=M.NoShading)
+        color = (:lightgray, 0.15),
+        transparency = true,
+        shading = M.NoShading)
 end
 
 _lon_from_xyz(p) = rad2deg(atan(p[2], p[1]))
-_lat_from_xyz(p) = rad2deg(asin(clamp(p[3] / sqrt(sum(p.^2)), -1, 1)))
+_lat_from_xyz(p) = rad2deg(asin(clamp(p[3] / sqrt(sum(p .^ 2)), -1, 1)))
 
 end  # module VisualizationPlotting

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -10,68 +10,27 @@ using GeometryBasics: Point3f
               show_edges::Bool = true,
               show_cell_ids::Bool = false,
               show_node_ids::Bool = false,
-              view::Symbol = Symbol("3d"),
-              projection::Symbol = :equirectangular,
-              n_arc_points::Int = 20,
+              n_arc_points::Int = 50,
               figsize::Tuple{Int,Int} = (800, 600),
               kwargs...) -> Figure
 
-Plot mesh wireframe. Returns a Makie `Figure`.
+Plot 3D mesh wireframe on a semi-transparent sphere background.
+Returns a Makie `Figure`.
 """
 function plot_mesh(g::AbstractManifoldMesh;
         show_nodes::Bool = false,
         show_edges::Bool = true,
         show_cell_ids::Bool = false,
         show_node_ids::Bool = false,
-        view::Symbol = Symbol("3d"),
-        projection::Symbol = :equirectangular,
-        n_arc_points::Int = 20,
+        n_arc_points::Int = 50,
         figsize::Tuple{Int, Int} = (800, 600),
         kwargs...)
-    view == Symbol("3d") ?
-    _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
-        show_node_ids, n_arc_points, figsize, kwargs...) :
-    view == Symbol("2d") ?
-    _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
-        show_node_ids, n_arc_points, projection,
-        figsize, kwargs...) :
-    error("Unsupported view: $view. Use Symbol(\"3d\") or Symbol(\"2d\").")
-end
-
-"""
-    plot_mesh_filled(g::AbstractManifoldMesh;
-                     show_edges::Bool = true,
-                     color_by = nothing,
-                     kwargs...) -> Figure
-
-Plot filled cell polygons with optional wireframe overlay. Returns a Makie `Figure`.
-
-# Keywords
-- `color_by = nothing`: callable taking cell index (`Int`) and returning a Makie color,
-  or `nothing` for default `lightblue`.
-"""
-function plot_mesh_filled(g::AbstractManifoldMesh;
-        show_edges::Bool = true,
-        color_by = nothing,
-        view::Symbol = Symbol("3d"),
-        n_arc_points::Int = 20,
-        figsize::Tuple{Int, Int} = (800, 600),
-        kwargs...)
-    view == Symbol("3d") ?
-    _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs...) :
-    view == Symbol("2d") ?
-    _plot_filled_2d(g; show_edges, color_by, n_arc_points, figsize, kwargs...) :
-    error("Unsupported view: $view. Use Symbol(\"3d\") or Symbol(\"2d\").")
-end
-
-# -- 3D wireframe --
-
-function _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
-        show_node_ids, n_arc_points, figsize, kwargs...)
     M = _require_makie()
 
     fig = M.Figure(; size = figsize)
     ax = M.LScene(fig[1, 1]; show_axis = false)
+
+    _add_sphere_background!(ax, M; R = _get_radius(g))
 
     if show_edges
         segs = edge_segments(g; n_arc_points)
@@ -106,13 +65,33 @@ function _plot_mesh_3d(g; show_nodes, show_edges, show_cell_ids,
     return fig
 end
 
-# -- 3D filled --
+"""
+    plot_mesh_filled(g::AbstractManifoldMesh;
+                     show_edges::Bool = true,
+                     color_by = nothing,
+                     n_arc_points::Int = 50,
+                     figsize::Tuple{Int,Int} = (800, 600),
+                     kwargs...) -> Figure
 
-function _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs...)
+Plot filled 3D cell polygons on a semi-transparent sphere background.
+Returns a Makie `Figure`.
+
+# Keywords
+- `color_by = nothing`: callable taking cell index (`Int`) and returning a Makie color,
+  or `nothing` for default `lightblue`.
+"""
+function plot_mesh_filled(g::AbstractManifoldMesh;
+        show_edges::Bool = true,
+        color_by = nothing,
+        n_arc_points::Int = 50,
+        figsize::Tuple{Int, Int} = (800, 600),
+        kwargs...)
     M = _require_makie()
 
     fig = M.Figure(; size = figsize)
     ax = M.LScene(fig[1, 1]; show_axis = false)
+
+    _add_sphere_background!(ax, M; R = _get_radius(g))
 
     polys = cell_polygons(g; n_arc_points)
     for (i, poly) in enumerate(polys)
@@ -131,95 +110,6 @@ function _plot_filled_3d(g; show_edges, color_by, n_arc_points, figsize, kwargs.
         for seg in segs
             if length(seg) > 1
                 M.lines!(ax, seg; color = :steelblue, linewidth = 0.5, kwargs...)
-            end
-        end
-    end
-
-    return fig
-end
-
-# -- 2D wireframe (equirectangular) --
-
-function _plot_mesh_2d(g; show_nodes, show_edges, show_cell_ids,
-        show_node_ids, n_arc_points, projection,
-        figsize, kwargs...)
-    projection == :equirectangular || error("Only :equirectangular projection is supported")
-    M = _require_makie()
-
-    fig = M.Figure(; size = figsize)
-    ax = M.Axis(fig[1, 1];
-        xlabel = "Longitude (deg)", ylabel = "Latitude (deg)",
-        title = "Mesh (equirectangular)")
-
-    if show_edges
-        segs = edge_segments(g; n_arc_points)
-        for seg in segs
-            if length(seg) > 1
-                lons = [_lon_from_xyz(p) for p in seg]
-                lats = [_lat_from_xyz(p) for p in seg]
-                M.lines!(ax, lons, lats; color = :steelblue, linewidth = 0.5, kwargs...)
-            end
-        end
-    end
-
-    if show_nodes
-        pts = node_points(g)
-        xs = [_lon_from_xyz(p) for p in pts]
-        ys = [_lat_from_xyz(p) for p in pts]
-        M.scatter!(ax, xs, ys; color = :orangered, markersize = 5, kwargs...)
-    end
-
-    if show_cell_ids
-        for cid in 1:num_cells(g)
-            c = cell_centroid(g, cid)
-            lon = _lon_from_xyz(Point3f(Float32.(c)))
-            lat = _lat_from_xyz(Point3f(Float32.(c)))
-            M.text!(ax, [lon], [lat]; text = ["$cid"], fontsize = 6, kwargs...)
-        end
-    end
-
-    if show_node_ids
-        for nid in 1:num_nodes(g)
-            c = node_coordinates(g, nid)
-            lon = _lon_from_xyz(Point3f(Float32.(c)))
-            lat = _lat_from_xyz(Point3f(Float32.(c)))
-            M.text!(
-                ax, [lon], [lat]; text = ["$nid"], fontsize = 5, color = :gray, kwargs...)
-        end
-    end
-
-    return fig
-end
-
-# -- 2D filled --
-
-function _plot_filled_2d(g; show_edges, color_by, n_arc_points, figsize, kwargs...)
-    M = _require_makie()
-
-    fig = M.Figure(; size = figsize)
-    ax = M.Axis(fig[1, 1];
-        xlabel = "Longitude (deg)", ylabel = "Latitude (deg)",
-        title = "Mesh (equirectangular)")
-
-    polys = cell_polygons(g; n_arc_points)
-    for poly in polys
-        if length(poly) >= 3
-            lons = [_lon_from_xyz(p) for p in poly]
-            lats = [_lat_from_xyz(p) for p in poly]
-            push!(lons, lons[1])
-            push!(lats, lats[1])
-            M.lines!(ax, lons, lats; color = :lightblue, linewidth = 1, kwargs...)
-            M.poly!(ax, lons, lats; color = :lightblue, strokewidth = 0, kwargs...)
-        end
-    end
-
-    if show_edges
-        segs = edge_segments(g; n_arc_points)
-        for seg in segs
-            if length(seg) > 1
-                lons = [_lon_from_xyz(p) for p in seg]
-                lats = [_lat_from_xyz(p) for p in seg]
-                M.lines!(ax, lons, lats; color = :steelblue, linewidth = 0.5, kwargs...)
             end
         end
     end
@@ -248,13 +138,11 @@ function _add_sphere_background!(ax, M; R = 1.0)
     xe = [R * cos(phiv) * sin(thetav) for thetav in theta, phiv in phi]
     ye = [R * sin(phiv) * sin(thetav) for thetav in theta, phiv in phi]
     ze = [R * cos(thetav) for thetav in theta, phiv in phi]
+    colors = fill(M.RGBA(0.9, 0.9, 0.9, 0.15), size(xe))
     M.surface!(ax, xe, ye, ze;
-        color = M.RGBA(0.8, 0.8, 0.8, 0.1),
+        color = colors,
         transparency = true,
         shading = M.NoShading)
 end
-
-_lon_from_xyz(p) = rad2deg(atan(p[2], p[1]))
-_lat_from_xyz(p) = rad2deg(asin(clamp(p[3] / sqrt(sum(p .^ 2)), -1, 1)))
 
 end  # module VisualizationPlotting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,5 @@ end
     include("test_latlon_edge_cases.jl")
     include("test_performance.jl")
     include("test_visualization_data.jl")
+    include("test_visualization_smoke.jl")
 end

--- a/test/test_visualization_smoke.jl
+++ b/test/test_visualization_smoke.jl
@@ -5,10 +5,11 @@ using Test
 using CairoMakie
 
 @testset "Visualization smoke tests" begin
-    grid = LatLonGrid(lat_edges=collect(-90.0:30.0:90.0), lon_edges=collect(0.0:60.0:360.0))
+    grid = LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))
 
     @testset "plot_mesh 3D wireframe" begin
-        fig = plot_mesh(grid; show_nodes=false, show_edges=true, view=Symbol("3d"), figsize=(400, 400))
+        fig = plot_mesh(grid; show_nodes = false, show_edges = true,
+            view = Symbol("3d"), figsize = (400, 400))
         @test fig isa Figure
         save("test_mesh_3d.png", fig)
         @test isfile("test_mesh_3d.png")
@@ -16,7 +17,7 @@ using CairoMakie
     end
 
     @testset "plot_mesh 2D equirectangular" begin
-        fig = plot_mesh(grid; view=Symbol("2d"), figsize=(400, 400))
+        fig = plot_mesh(grid; view = Symbol("2d"), figsize = (400, 400))
         @test fig isa Figure
         save("test_mesh_2d.png", fig)
         @test isfile("test_mesh_2d.png")
@@ -24,7 +25,8 @@ using CairoMakie
     end
 
     @testset "plot_mesh_filled 3D" begin
-        fig = plot_mesh_filled(grid; show_edges=true, view=Symbol("3d"), figsize=(400, 400))
+        fig = plot_mesh_filled(grid; show_edges = true, view = Symbol("3d"), figsize = (
+            400, 400))
         @test fig isa Figure
         save("test_filled_3d.png", fig)
         @test isfile("test_filled_3d.png")
@@ -32,7 +34,7 @@ using CairoMakie
     end
 
     @testset "plot_mesh_filled 2D" begin
-        fig = plot_mesh_filled(grid; view=Symbol("2d"), figsize=(400, 400))
+        fig = plot_mesh_filled(grid; view = Symbol("2d"), figsize = (400, 400))
         @test fig isa Figure
         save("test_filled_2d.png", fig)
         @test isfile("test_filled_2d.png")
@@ -40,11 +42,12 @@ using CairoMakie
     end
 
     @testset "invalid view raises error" begin
-        @test_throws ErrorException plot_mesh(grid; view=:invalid)
+        @test_throws ErrorException plot_mesh(grid; view = :invalid)
     end
 
     @testset "color_by function" begin
-        fig = plot_mesh_filled(grid; color_by=i -> (i % 2 == 0 ? :red : :blue), view=Symbol("3d"), figsize=(400, 400))
+        fig = plot_mesh_filled(grid; color_by = i -> (i % 2 == 0 ? :red : :blue),
+            view = Symbol("3d"), figsize = (400, 400))
         @test fig isa Figure
     end
 end

--- a/test/test_visualization_smoke.jl
+++ b/test/test_visualization_smoke.jl
@@ -1,0 +1,50 @@
+using ManifoldMeshes
+using Manifolds
+using Test
+
+using CairoMakie
+
+@testset "Visualization smoke tests" begin
+    grid = LatLonGrid(lat_edges=collect(-90.0:30.0:90.0), lon_edges=collect(0.0:60.0:360.0))
+
+    @testset "plot_mesh 3D wireframe" begin
+        fig = plot_mesh(grid; show_nodes=false, show_edges=true, view=Symbol("3d"), figsize=(400, 400))
+        @test fig isa Figure
+        save("test_mesh_3d.png", fig)
+        @test isfile("test_mesh_3d.png")
+        rm("test_mesh_3d.png")
+    end
+
+    @testset "plot_mesh 2D equirectangular" begin
+        fig = plot_mesh(grid; view=Symbol("2d"), figsize=(400, 400))
+        @test fig isa Figure
+        save("test_mesh_2d.png", fig)
+        @test isfile("test_mesh_2d.png")
+        rm("test_mesh_2d.png")
+    end
+
+    @testset "plot_mesh_filled 3D" begin
+        fig = plot_mesh_filled(grid; show_edges=true, view=Symbol("3d"), figsize=(400, 400))
+        @test fig isa Figure
+        save("test_filled_3d.png", fig)
+        @test isfile("test_filled_3d.png")
+        rm("test_filled_3d.png")
+    end
+
+    @testset "plot_mesh_filled 2D" begin
+        fig = plot_mesh_filled(grid; view=Symbol("2d"), figsize=(400, 400))
+        @test fig isa Figure
+        save("test_filled_2d.png", fig)
+        @test isfile("test_filled_2d.png")
+        rm("test_filled_2d.png")
+    end
+
+    @testset "invalid view raises error" begin
+        @test_throws ErrorException plot_mesh(grid; view=:invalid)
+    end
+
+    @testset "color_by function" begin
+        fig = plot_mesh_filled(grid; color_by=i -> (i % 2 == 0 ? :red : :blue), view=Symbol("3d"), figsize=(400, 400))
+        @test fig isa Figure
+    end
+end

--- a/test/test_visualization_smoke.jl
+++ b/test/test_visualization_smoke.jl
@@ -8,46 +8,23 @@ using CairoMakie
     grid = LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))
 
     @testset "plot_mesh 3D wireframe" begin
-        fig = plot_mesh(grid; show_nodes = false, show_edges = true,
-            view = Symbol("3d"), figsize = (400, 400))
+        fig = plot_mesh(grid; show_nodes = false, show_edges = true, figsize = (400, 400))
         @test fig isa Figure
         save("test_mesh_3d.png", fig)
         @test isfile("test_mesh_3d.png")
         rm("test_mesh_3d.png")
     end
 
-    @testset "plot_mesh 2D equirectangular" begin
-        fig = plot_mesh(grid; view = Symbol("2d"), figsize = (400, 400))
-        @test fig isa Figure
-        save("test_mesh_2d.png", fig)
-        @test isfile("test_mesh_2d.png")
-        rm("test_mesh_2d.png")
-    end
-
     @testset "plot_mesh_filled 3D" begin
-        fig = plot_mesh_filled(grid; show_edges = true, view = Symbol("3d"), figsize = (
-            400, 400))
+        fig = plot_mesh_filled(grid; show_edges = true, figsize = (400, 400))
         @test fig isa Figure
         save("test_filled_3d.png", fig)
         @test isfile("test_filled_3d.png")
         rm("test_filled_3d.png")
     end
 
-    @testset "plot_mesh_filled 2D" begin
-        fig = plot_mesh_filled(grid; view = Symbol("2d"), figsize = (400, 400))
-        @test fig isa Figure
-        save("test_filled_2d.png", fig)
-        @test isfile("test_filled_2d.png")
-        rm("test_filled_2d.png")
-    end
-
-    @testset "invalid view raises error" begin
-        @test_throws ErrorException plot_mesh(grid; view = :invalid)
-    end
-
     @testset "color_by function" begin
-        fig = plot_mesh_filled(grid; color_by = i -> (i % 2 == 0 ? :red : :blue),
-            view = Symbol("3d"), figsize = (400, 400))
+        fig = plot_mesh_filled(grid; color_by = i -> (i % 2 == 0 ? :red : :blue), figsize = (400, 400))
         @test fig isa Figure
     end
 end


### PR DESCRIPTION
## Summary

Add 3D mesh visualization functions \`plot_mesh\` and \`plot_mesh_filled\` with semi-transparent sphere background.

## Changes

- \`src/visualization/plotting.jl\` — Plotting layer with:
  - \`plot_mesh\` — 3D wireframe mesh on semi-transparent sphere background
  - \`plot_mesh_filled\` — Filled cell polygons with optional wireframe overlay
  - \`color_by\` option for per-cell coloring
  - Denser wireframe (default \`n_arc_points = 50\`)
- \`src/visualization/mesh_data.jl\` — Data extraction: \`node_points\`, \`edge_segments\`, \`cell_polygons\`
- \`test/test_visualization_smoke.jl\` — Smoke tests for 3D wireframe, filled, and color_by modes
- \`src/ManifoldMeshes.jl\` — Exports \`plot_mesh\` and \`plot_mesh_filled\`
- \`Project.toml\` — \`CairoMakie\` added as a runtime dependency

## Design

- Visualization builds on the existing \`mesh_data.jl\` geometric primitives layer
- Great-circle arcs discretized via SLERP for accurate spherical geometry
- Sphere background rendered with \`RGBA(0.9, 0.9, 0.9, 0.15)\` transparency
- Both functions accept standard Makie keyword arguments

## Test Results

- 3987/3987 tests pass
- 11/11 Aqua code quality checks pass