### PR TITLE
refactor(visualization): generic grid support + batched rendering + new example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /docs/build/
 /docs/superpowers/
 /.worktrees/
+/examples/*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Generic visualization across all grid types**: `edge_segments()` and `cell_polygons()` now derive edges from `cell_nodes` boundary order, eliminating hardcoded quad-cell assumptions and working correctly for any grid topology
+- **`cell_triangles()` function**: Decomposes each cell into K triangles fanning from the sphere-projected centroid; returns shared-vertex `(vertices, faces)` suitable for `GeometryBasics.Mesh`
+- **Batched rendering**: Edge wireframes use a single NaN-separated `lines!()` call; filled meshes use a single `mesh!(verts, faces)` call with per-vertex coloring for improved performance
+- **Extended visualization tests**: Both `test_visualization_data.jl` and `test_visualization_smoke.jl` now cover all 4 grid types; restored `slerp` and `node_points` unit tests
+- **`examples/grids_visualization.jl`**: Standalone script producing a 4×2 comparison figure of all S² grid types
+
+### Fixed
+
+- Explicit imports and type stability in visualization module
+- Hardened color array type for cross-backend compatibility
+
 ## [0.3.0] - 2026-05-21
 
 ### Added

--- a/examples/grids_visualization.jl
+++ b/examples/grids_visualization.jl
@@ -1,0 +1,119 @@
+# examples/grids_visualization.jl
+# Standalone script: visualize all 4 S² grid types at coarse and fine resolutions.
+#
+# Run with:
+#   julia --project=. examples/grids_visualization.jl
+#
+# Output:
+#   examples/grids_visualization.png
+
+using ManifoldMeshes
+using CairoMakie
+using GeometryBasics: Point3f
+using LinearAlgebra: norm
+
+# ── Tunable constants ──────────────────────────────────────────────────────────
+
+const OUTPUT_PATH = joinpath(@__DIR__, "grids_visualization.png")
+const FIG_SIZE    = (1200, 1600)   # (width, height) in pixels
+const N_ARC       = 30             # edge discretization points
+
+# ── Grid definitions (coarse / fine) ─────────────────────────────────────────
+
+# LatLon: structured lat-lon grid
+#   Coarse: 6 lat bands × 8 lon bands  = 48 cells
+#   Fine:   24 lat bands × 32 lon bands = 768 cells
+latlon_coarse = LatLonGrid(
+    lat_edges = collect(range(-90.0, 90.0, length = 7)),
+    lon_edges = collect(range(0.0, 360.0, length = 9)),
+)
+latlon_fine = LatLonGrid(
+    lat_edges = collect(range(-90.0, 90.0, length = 25)),
+    lon_edges = collect(range(0.0, 360.0, length = 33)),
+)
+
+# CubedSphere: 6-face gnomonic projection
+#   Coarse: n=4  → 6 × 4²  = 96 cells
+#   Fine:   n=16 → 6 × 16² = 1536 cells
+cubed_coarse = CubedSphereGrid(n = 4)
+cubed_fine   = CubedSphereGrid(n = 16)
+
+# ReducedGaussian: octahedral Gaussian lat bands
+#   Coarse: nlat=8  → ~96 cells
+#   Fine:   nlat=32 → ~1536 cells
+gauss_coarse = ReducedGaussianGrid(nlat = 8)
+gauss_fine   = ReducedGaussianGrid(nlat = 32)
+
+# HEALPix: hierarchical equal-area pixels
+#   Coarse: nside=2 → 12 × 2²  = 48 cells
+#   Fine:   nside=8 → 12 × 8²  = 768 cells
+healpix_coarse = HEALPixGrid(nside = 2)
+healpix_fine   = HEALPixGrid(nside = 8)
+
+# ── Bundle for iteration ──────────────────────────────────────────────────────
+
+grids = [
+    ("LatLon",          latlon_coarse,  latlon_fine),
+    ("CubedSphere",     cubed_coarse,   cubed_fine),
+    ("ReducedGaussian", gauss_coarse,   gauss_fine),
+    ("HEALPix",         healpix_coarse, healpix_fine),
+]
+
+# ── Helper: draw mesh wireframe on an existing LScene ─────────────────────────
+
+function draw_mesh!(ax, g; show_nodes::Bool = true, show_edges::Bool = true)
+    # Semi-transparent sphere background
+    n = 64
+    theta = LinRange(0, pi, n)
+    phi   = LinRange(-pi, pi, 2n)
+    R = norm(node_coordinates(g, 1))
+    xe = [R * cos(phiv) * sin(thetav) for thetav in theta, phiv in phi]
+    ye = [R * sin(phiv) * sin(thetav) for thetav in theta, phiv in phi]
+    ze = [R * cos(thetav)              for thetav in theta, phiv in phi]
+    colors = fill(RGBAf(0.9, 0.9, 0.9, 0.15), size(xe))
+    surface!(ax, xe, ye, ze;
+        color = colors, transparency = true, shading = NoShading)
+
+    if show_edges
+        segs = edge_segments(g; n_arc_points = N_ARC)
+        pts = Point3f[]
+        nan_pt = Point3f(NaN32, NaN32, NaN32)
+        for seg in segs
+            if length(seg) >= 2
+                append!(pts, seg)
+                push!(pts, nan_pt)
+            end
+        end
+        isempty(pts) || lines!(ax, pts; color = :steelblue, linewidth = 0.5)
+    end
+
+    if show_nodes
+        pts = node_points(g)
+        meshscatter!(ax, pts; color = :orangered, markersize = 0.03)
+    end
+
+    return nothing
+end
+
+# ── Create figure and plot ────────────────────────────────────────────────────
+
+fig = Figure(size = FIG_SIZE)
+
+for (row, (name, coarse, fine)) in enumerate(grids)
+    # Coarse resolution (left column)
+    Label(fig[row, 1, Top()], "$name (coarse, $(num_cells(coarse)) cells)";
+        fontsize = 14, padding = (0, 0, 10, 0))
+    ax1 = LScene(fig[row, 1]; show_axis = false)
+    draw_mesh!(ax1, coarse)
+
+    # Fine resolution (right column)
+    Label(fig[row, 2, Top()], "$name (fine, $(num_cells(fine)) cells)";
+        fontsize = 14, padding = (0, 0, 10, 0))
+    ax2 = LScene(fig[row, 2]; show_axis = false)
+    draw_mesh!(ax2, fine)
+end
+
+# ── Save ──────────────────────────────────────────────────────────────────────
+
+save(OUTPUT_PATH, fig)
+println("Saved visualization to: $OUTPUT_PATH")

--- a/examples/grids_visualization.jl
+++ b/examples/grids_visualization.jl
@@ -15,7 +15,7 @@ using LinearAlgebra: norm
 # ── Tunable constants ──────────────────────────────────────────────────────────
 
 const OUTPUT_PATH = joinpath(@__DIR__, "grids_visualization.png")
-const FIG_SIZE    = (1200, 1600)   # (width, height) in pixels
+const FIG_SIZE    = (900, 1100)    # (width, height) in pixels
 const N_ARC       = 30             # edge discretization points
 
 # ── Grid definitions (coarse / fine) ─────────────────────────────────────────
@@ -52,16 +52,17 @@ healpix_fine   = HEALPixGrid(nside = 8)
 
 # ── Bundle for iteration ──────────────────────────────────────────────────────
 
+# (name, coarse_grid, fine_grid, color)
 grids = [
-    ("LatLon",          latlon_coarse,  latlon_fine),
-    ("CubedSphere",     cubed_coarse,   cubed_fine),
-    ("ReducedGaussian", gauss_coarse,   gauss_fine),
-    ("HEALPix",         healpix_coarse, healpix_fine),
+    ("LatLon",          latlon_coarse,  latlon_fine,  :steelblue3),
+    ("CubedSphere",     cubed_coarse,   cubed_fine,   :seagreen),
+    ("ReducedGaussian", gauss_coarse,   gauss_fine,   :mediumpurple3),
+    ("HEALPix",         healpix_coarse, healpix_fine, :chocolate3),
 ]
 
 # ── Helper: draw mesh wireframe on an existing LScene ─────────────────────────
 
-function draw_mesh!(ax, g; show_nodes::Bool = true, show_edges::Bool = true)
+function draw_mesh!(ax, g; edge_color = :steelblue, show_edges::Bool = true)
     # Semi-transparent sphere background
     n = 64
     theta = LinRange(0, pi, n)
@@ -70,7 +71,7 @@ function draw_mesh!(ax, g; show_nodes::Bool = true, show_edges::Bool = true)
     xe = [R * cos(phiv) * sin(thetav) for thetav in theta, phiv in phi]
     ye = [R * sin(phiv) * sin(thetav) for thetav in theta, phiv in phi]
     ze = [R * cos(thetav)              for thetav in theta, phiv in phi]
-    colors = fill(RGBAf(0.9, 0.9, 0.9, 0.15), size(xe))
+    colors = fill(RGBAf(0.85, 0.85, 0.9, 0.25), size(xe))
     surface!(ax, xe, ye, ze;
         color = colors, transparency = true, shading = NoShading)
 
@@ -84,12 +85,7 @@ function draw_mesh!(ax, g; show_nodes::Bool = true, show_edges::Bool = true)
                 push!(pts, nan_pt)
             end
         end
-        isempty(pts) || lines!(ax, pts; color = :steelblue, linewidth = 0.5)
-    end
-
-    if show_nodes
-        pts = node_points(g)
-        meshscatter!(ax, pts; color = :orangered, markersize = 0.03)
+        isempty(pts) || lines!(ax, pts; color = edge_color, linewidth = 0.8)
     end
 
     return nothing
@@ -99,19 +95,23 @@ end
 
 fig = Figure(size = FIG_SIZE)
 
-for (row, (name, coarse, fine)) in enumerate(grids)
+for (row, (name, coarse, fine, color)) in enumerate(grids)
     # Coarse resolution (left column)
     Label(fig[row, 1, Top()], "$name (coarse, $(num_cells(coarse)) cells)";
-        fontsize = 14, padding = (0, 0, 10, 0))
+        fontsize = 12, font = :bold, padding = (0, 0, 5, 0))
     ax1 = LScene(fig[row, 1]; show_axis = false)
-    draw_mesh!(ax1, coarse)
+    draw_mesh!(ax1, coarse; edge_color = color)
 
     # Fine resolution (right column)
     Label(fig[row, 2, Top()], "$name (fine, $(num_cells(fine)) cells)";
-        fontsize = 14, padding = (0, 0, 10, 0))
+        fontsize = 12, font = :bold, padding = (0, 0, 5, 0))
     ax2 = LScene(fig[row, 2]; show_axis = false)
-    draw_mesh!(ax2, fine)
+    draw_mesh!(ax2, fine; edge_color = color)
 end
+
+# Tighten layout gaps
+rowgap!(fig.layout, 15)
+colgap!(fig.layout, 25)
 
 # ── Save ──────────────────────────────────────────────────────────────────────
 

--- a/examples/grids_visualization.jl
+++ b/examples/grids_visualization.jl
@@ -15,8 +15,8 @@ using LinearAlgebra: norm
 # ── Tunable constants ──────────────────────────────────────────────────────────
 
 const OUTPUT_PATH = joinpath(@__DIR__, "grids_visualization.png")
-const FIG_SIZE    = (900, 1100)    # (width, height) in pixels
-const N_ARC       = 30             # edge discretization points
+const FIG_SIZE = (900, 1100)    # (width, height) in pixels
+const N_ARC = 30             # edge discretization points
 
 # ── Grid definitions (coarse / fine) ─────────────────────────────────────────
 
@@ -25,39 +25,39 @@ const N_ARC       = 30             # edge discretization points
 #   Fine:   24 lat bands × 32 lon bands = 768 cells
 latlon_coarse = LatLonGrid(
     lat_edges = collect(range(-90.0, 90.0, length = 7)),
-    lon_edges = collect(range(0.0, 360.0, length = 9)),
+    lon_edges = collect(range(0.0, 360.0, length = 9))
 )
 latlon_fine = LatLonGrid(
     lat_edges = collect(range(-90.0, 90.0, length = 25)),
-    lon_edges = collect(range(0.0, 360.0, length = 33)),
+    lon_edges = collect(range(0.0, 360.0, length = 33))
 )
 
 # CubedSphere: 6-face gnomonic projection
 #   Coarse: n=4  → 6 × 4²  = 96 cells
 #   Fine:   n=16 → 6 × 16² = 1536 cells
 cubed_coarse = CubedSphereGrid(n = 4)
-cubed_fine   = CubedSphereGrid(n = 16)
+cubed_fine = CubedSphereGrid(n = 16)
 
 # ReducedGaussian: octahedral Gaussian lat bands
 #   Coarse: nlat=8  → ~96 cells
 #   Fine:   nlat=32 → ~1536 cells
 gauss_coarse = ReducedGaussianGrid(nlat = 8)
-gauss_fine   = ReducedGaussianGrid(nlat = 32)
+gauss_fine = ReducedGaussianGrid(nlat = 32)
 
 # HEALPix: hierarchical equal-area pixels
 #   Coarse: nside=2 → 12 × 2²  = 48 cells
 #   Fine:   nside=8 → 12 × 8²  = 768 cells
 healpix_coarse = HEALPixGrid(nside = 2)
-healpix_fine   = HEALPixGrid(nside = 8)
+healpix_fine = HEALPixGrid(nside = 8)
 
 # ── Bundle for iteration ──────────────────────────────────────────────────────
 
 # (name, coarse_grid, fine_grid, color)
 grids = [
-    ("LatLon",          latlon_coarse,  latlon_fine,  :steelblue3),
-    ("CubedSphere",     cubed_coarse,   cubed_fine,   :seagreen),
-    ("ReducedGaussian", gauss_coarse,   gauss_fine,   :mediumpurple3),
-    ("HEALPix",         healpix_coarse, healpix_fine, :chocolate3),
+    ("LatLon", latlon_coarse, latlon_fine, :steelblue3),
+    ("CubedSphere", cubed_coarse, cubed_fine, :seagreen),
+    ("ReducedGaussian", gauss_coarse, gauss_fine, :mediumpurple3),
+    ("HEALPix", healpix_coarse, healpix_fine, :chocolate3)
 ]
 
 # ── Helper: draw mesh wireframe on an existing LScene ─────────────────────────
@@ -66,11 +66,11 @@ function draw_mesh!(ax, g; edge_color = :steelblue, show_edges::Bool = true)
     # Semi-transparent sphere background
     n = 64
     theta = LinRange(0, pi, n)
-    phi   = LinRange(-pi, pi, 2n)
+    phi = LinRange(-pi, pi, 2n)
     R = norm(node_coordinates(g, 1))
     xe = [R * cos(phiv) * sin(thetav) for thetav in theta, phiv in phi]
     ye = [R * sin(phiv) * sin(thetav) for thetav in theta, phiv in phi]
-    ze = [R * cos(thetav)              for thetav in theta, phiv in phi]
+    ze = [R * cos(thetav) for thetav in theta, phiv in phi]
     colors = fill(RGBAf(0.85, 0.85, 0.9, 0.25), size(xe))
     surface!(ax, xe, ye, ze;
         color = colors, transparency = true, shading = NoShading)

--- a/src/ManifoldMeshes.jl
+++ b/src/ManifoldMeshes.jl
@@ -24,7 +24,7 @@ export cell_nodes, cell_cells, node_cells, cell_edges
 export edge_length, edge_midpoint, edge_outward_normal
 export boundary_nodes, boundary_edges
 export dual, has_dual, cell_face, cell_local_2d
-export slerp, node_points, edge_segments, cell_polygons
+export slerp, node_points, edge_segments, cell_polygons, cell_triangles
 
 include("sphere/utils.jl")
 include("sphere/latlon.jl")

--- a/src/visualization/mesh_data.jl
+++ b/src/visualization/mesh_data.jl
@@ -95,3 +95,51 @@ function cell_polygons(g::AbstractManifoldMesh; n_arc_points::Int = 20)
     end
     return polygons
 end
+
+"""
+    cell_triangles(g::AbstractManifoldMesh) -> (Vector{Point3f}, Vector{Int})
+
+Return triangle-mesh data for all cells as a shared-vertex list.
+Each cell with K boundary nodes is decomposed into K triangles fanning
+from the cell centroid (projected onto the sphere surface) to consecutive
+boundary-node pairs.  The returned `(vertices, faces)` can be passed
+ directly to `GeometryBasics.Mesh`.
+"""
+function cell_triangles(g::AbstractManifoldMesh)
+    vertices = Point3f[]
+    faces = Int[]
+    offset = 0
+    R = _get_radius(g)
+    for cid in 1:num_cells(g)
+        ns = cell_nodes(g, cid)
+        K = length(ns)
+        K < 3 && continue
+
+        # Centroid projected onto sphere surface
+        raw_c = SVector{3, Float64}(cell_centroid(g, cid))
+        c_norm = norm(raw_c)
+        centroid = c_norm > 0 ? Point3f(Float32.(raw_c ./ c_norm .* R)) : Point3f(Float32.(raw_c))
+        push!(vertices, centroid)
+
+        # K boundary nodes
+        for n in ns
+            push!(vertices, Point3f(Float32.(node_coordinates(g, n))))
+        end
+
+        # K triangles: centroid(1) + boundary(i) + boundary(i+1)
+        for i in 1:K
+            v1 = offset + 1
+            v2 = offset + 1 + i
+            v3 = offset + 1 + mod1(i + 1, K)
+            push!(faces, v1, v2, v3)
+        end
+
+        offset += K + 1
+    end
+    return vertices, faces
+end
+
+function _get_radius(g::AbstractManifoldMesh)
+    c = node_coordinates(g, 1)
+    return sqrt(sum(c .^ 2))
+end

--- a/src/visualization/mesh_data.jl
+++ b/src/visualization/mesh_data.jl
@@ -41,55 +41,29 @@ function node_points(g::AbstractManifoldMesh)
 end
 
 """
-    _build_edge_endpoint_map(g::AbstractManifoldMesh) -> Dict{Int, Tuple{Int,Int}}
-
-Reconstruct edge-to-endpoint-node mapping from the public cell interface.
-For each cell, edges are ordered (south, north, west, east) and nodes are
-ordered (SW, SE, NE, NW), giving:
-  - south edge: SW -> SE  (nodes 1-2)
-  - north edge: NW -> NE  (nodes 4-3)
-  - west edge:  SW -> NW  (nodes 1-4)
-  - east edge:  SE -> NE  (nodes 2-3)
-"""
-function _build_edge_endpoint_map(g::AbstractManifoldMesh)
-    # node_pair_for_edge[edge_id] = (node_a, node_b)
-    node_pair_for_edge = Dict{Int, Tuple{Int, Int}}()
-    for cid in 1:num_cells(g)
-        ns = cell_nodes(g, cid)
-        es = cell_edges(g, cid)
-        # south edge: SW(1) -> SE(2)
-        _register_edge_pair!(node_pair_for_edge, es[1], ns[1], ns[2])
-        # north edge: NW(4) -> NE(3)
-        _register_edge_pair!(node_pair_for_edge, es[2], ns[4], ns[3])
-        # west edge: SW(1) -> NW(4)
-        _register_edge_pair!(node_pair_for_edge, es[3], ns[1], ns[4])
-        # east edge: SE(2) -> NE(3)
-        _register_edge_pair!(node_pair_for_edge, es[4], ns[2], ns[3])
-    end
-    return node_pair_for_edge
-end
-
-function _register_edge_pair!(
-        d::Dict{Int, Tuple{Int, Int}}, edge_id::Int, a::Int, b::Int)
-    if !haskey(d, edge_id)
-        d[edge_id] = (a, b)
-    end
-end
-
-"""
     edge_segments(g::AbstractManifoldMesh; n_arc_points::Int=20) -> Vector{Vector{Point3f}}
 
-Return discretized great-circle arcs for each edge, as a vector of `Point3f` arrays.
+Return discretized great-circle arcs for each unique undirected edge,
+as a vector of `Point3f` arrays. Edges are derived from `cell_nodes`
+boundary order, so no `cell_edges` ordering is assumed.
 Degenerate edges (coincident endpoints) return a single-point segment.
 """
 function edge_segments(g::AbstractManifoldMesh; n_arc_points::Int = 20)
-    edge_map = _build_edge_endpoint_map(g)
-    segments = Vector{Vector{Point3f}}(undef, num_edges(g))
-    for eid in 1:num_edges(g)
-        n1_id, n2_id = edge_map[eid]
-        p1 = node_coordinates(g, n1_id)
-        p2 = node_coordinates(g, n2_id)
-        segments[eid] = slerp(p1, p2, n_arc_points)
+    seen = Set{Tuple{Int, Int}}()
+    segments = Vector{Vector{Point3f}}()
+    for cid in 1:num_cells(g)
+        ns = cell_nodes(g, cid)
+        K = length(ns)
+        for i in 1:K
+            n1, n2 = ns[i], ns[mod1(i + 1, K)]
+            key = n1 < n2 ? (n1, n2) : (n2, n1)
+            if key ∉ seen
+                push!(seen, key)
+                p1 = node_coordinates(g, n1)
+                p2 = node_coordinates(g, n2)
+                push!(segments, slerp(p1, p2, n_arc_points))
+            end
+        end
     end
     return segments
 end
@@ -99,48 +73,25 @@ end
 
 Return closed cell boundaries as discretized great-circle polygons.
 Each polygon is a vector of `Point3f` where the first point equals the last.
-Edges are ordered: south, east, north (reversed), west (reversed).
+Edges are derived from consecutive `cell_nodes` in boundary order, so no
+`cell_edges` ordering is assumed.
 """
 function cell_polygons(g::AbstractManifoldMesh; n_arc_points::Int = 20)
-    edge_map = _build_edge_endpoint_map(g)
     polygons = Vector{Vector{Point3f}}(undef, num_cells(g))
-
     for cid in 1:num_cells(g)
         ns = cell_nodes(g, cid)
-        es = cell_edges(g, cid)
-
-        # Build arcs for each edge
-        south_arc = slerp(node_coordinates(g, ns[1]), node_coordinates(g, ns[2]), n_arc_points)
-        east_arc = slerp(node_coordinates(g, ns[2]), node_coordinates(g, ns[3]), n_arc_points)
-        north_arc = slerp(node_coordinates(g, ns[4]), node_coordinates(g, ns[3]), n_arc_points)
-        west_arc = slerp(node_coordinates(g, ns[1]), node_coordinates(g, ns[4]), n_arc_points)
-
-        # Concatenate: south + east + north(reversed) + west(reversed)
-        # Skip first point of each subsequent arc to avoid duplication at corners
-        total_len = length(south_arc) + (length(east_arc) - 1) +
-                    (length(north_arc) - 1) + (length(west_arc) - 1)
-        polygon = Vector{Point3f}(undef, total_len)
-
-        idx = 1
-        for p in south_arc
-            polygon[idx] = p
-            idx += 1
+        K = length(ns)
+        polygon = Point3f[]
+        for i in 1:K
+            n1, n2 = ns[i], ns[mod1(i + 1, K)]
+            arc = slerp(node_coordinates(g, n1), node_coordinates(g, n2), n_arc_points)
+            if i == 1
+                append!(polygon, arc)
+            else
+                append!(polygon, arc[2:end])
+            end
         end
-        for i in 2:length(east_arc)
-            polygon[idx] = east_arc[i]
-            idx += 1
-        end
-        for p in reverse(north_arc)[2:end]
-            polygon[idx] = p
-            idx += 1
-        end
-        for p in reverse(west_arc)[2:end]
-            polygon[idx] = p
-            idx += 1
-        end
-
         polygons[cid] = polygon
     end
-
     return polygons
 end

--- a/src/visualization/mesh_data.jl
+++ b/src/visualization/mesh_data.jl
@@ -1,3 +1,7 @@
+using StaticArrays: SVector
+using LinearAlgebra: dot, norm
+using GeometryBasics: Point3f
+
 """
     slerp(p1::SVector{3,Float64}, p2::SVector{3,Float64}, n::Int) -> Vector{Point3f}
 
@@ -45,7 +49,8 @@ end
 
 Return discretized great-circle arcs for each unique undirected edge,
 as a vector of `Point3f` arrays. Edges are derived from `cell_nodes`
-boundary order, so no `cell_edges` ordering is assumed.
+boundary order, so no `cell_edges` ordering is assumed.  For manifold
+meshes the number of unique undirected edges equals `num_edges(g)`.
 Degenerate edges (coincident endpoints) return a single-point segment.
 """
 function edge_segments(g::AbstractManifoldMesh; n_arc_points::Int = 20)
@@ -118,7 +123,8 @@ function cell_triangles(g::AbstractManifoldMesh)
         # Centroid projected onto sphere surface
         raw_c = SVector{3, Float64}(cell_centroid(g, cid))
         c_norm = norm(raw_c)
-        centroid = c_norm > 0 ? Point3f(Float32.(raw_c ./ c_norm .* R)) : Point3f(Float32.(raw_c))
+        centroid = c_norm > 0 ? Point3f(Float32.(raw_c ./ c_norm .* R)) :
+                   Point3f(Float32.(raw_c))
         push!(vertices, centroid)
 
         # K boundary nodes
@@ -139,6 +145,12 @@ function cell_triangles(g::AbstractManifoldMesh)
     return vertices, faces
 end
 
+"""
+    _get_radius(g::AbstractManifoldMesh)
+
+Return the sphere radius, assuming all nodes lie on a sphere centred at
+the origin.  Uses node 1 as the representative sample.
+"""
 function _get_radius(g::AbstractManifoldMesh)
     c = node_coordinates(g, 1)
     return sqrt(sum(c .^ 2))

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -2,7 +2,7 @@ module VisualizationPlotting
 
 using CairoMakie
 using ..ManifoldMeshes
-using ..ManifoldMeshes: node_points, edge_segments, cell_polygons
+using ..ManifoldMeshes: node_points, edge_segments, cell_polygons, _get_radius
 using GeometryBasics: Point3f
 
 """

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -104,7 +104,7 @@ function plot_mesh_filled(g::AbstractManifoldMesh;
             :lightblue
         else
             # Per-vertex coloring: each cell's K+1 vertices share the same color
-            color_arr = typeof(color_by(1))[]
+            color_arr = Any[]
             for cid in 1:num_cells(g)
                 ns = cell_nodes(g, cid)
                 K = length(ns)

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -98,25 +98,36 @@ function plot_mesh_filled(g::AbstractManifoldMesh;
 
     _add_sphere_background!(ax, M; R = _get_radius(g))
 
-    polys = cell_polygons(g; n_arc_points)
-    for (i, poly) in enumerate(polys)
-        if length(poly) >= 3
-            center = poly[1]
-            color = color_by === nothing ? :lightblue : color_by(i)
-            for k in 2:(length(poly) - 1)
-                M.mesh!(ax, [center, poly[k], poly[k + 1]];
-                    color = color, transparency = true, shading = M.NoShading, kwargs...)
+    verts, faces = cell_triangles(g)
+    if !isempty(faces)
+        colors = if color_by === nothing
+            :lightblue
+        else
+            # Per-vertex coloring: each cell's K+1 vertices share the same color
+            color_arr = typeof(color_by(1))[]
+            for cid in 1:num_cells(g)
+                ns = cell_nodes(g, cid)
+                K = length(ns)
+                K < 3 && continue
+                c = color_by(cid)
+                append!(color_arr, fill(c, K + 1))
             end
+            color_arr
         end
+        M.mesh!(ax, verts, faces; color = colors, shading = M.NoShading, kwargs...)
     end
 
     if show_edges
         segs = edge_segments(g; n_arc_points)
+        pts = Point3f[]
+        nan_pt = Point3f(NaN32, NaN32, NaN32)
         for seg in segs
-            if length(seg) > 1
-                M.lines!(ax, seg; color = :steelblue, linewidth = 0.5, kwargs...)
+            if length(seg) >= 2
+                append!(pts, seg)
+                push!(pts, nan_pt)
             end
         end
+        isempty(pts) || M.lines!(ax, pts; color = :steelblue, linewidth = 0.5, kwargs...)
     end
 
     return fig
@@ -126,11 +137,6 @@ end
 
 function _require_makie()
     return CairoMakie
-end
-
-function _get_radius(g::AbstractManifoldMesh)
-    c = node_coordinates(g, 1)
-    return sqrt(sum(c .^ 2))
 end
 
 function _add_sphere_background!(ax, M; R = 1.0)

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -35,11 +35,15 @@ function plot_mesh(g::AbstractManifoldMesh;
 
     if show_edges
         segs = edge_segments(g; n_arc_points)
+        pts = Point3f[]
+        nan_pt = Point3f(NaN32, NaN32, NaN32)
         for seg in segs
-            if length(seg) > 1
-                M.lines!(ax, seg; color = :steelblue, linewidth = 0.5, kwargs...)
+            if length(seg) >= 2
+                append!(pts, seg)
+                push!(pts, nan_pt)
             end
         end
+        isempty(pts) || M.lines!(ax, pts; color = :steelblue, linewidth = 0.5, kwargs...)
     end
 
     if show_nodes

--- a/test/test_visualization_data.jl
+++ b/test/test_visualization_data.jl
@@ -1,58 +1,53 @@
 using ManifoldMeshes
 using Manifolds
-using StaticArrays
 using Test
-using GeometryBasics
+using GeometryBasics: Point3f
 using LinearAlgebra
 
 @testset "Visualization data extraction" begin
-    grid = LatLonGrid(lat_edges = Float64.(collect(-90:30:90)), lon_edges = Float64.(collect(0:60:360)))
+    grids = [
+        ("LatLonGrid", LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))),
+        ("CubedSphereGrid", CubedSphereGrid(n = 4)),
+        ("ReducedGaussianGrid", ReducedGaussianGrid(nlat = 8)),
+        ("HEALPixGrid", HEALPixGrid(nside = 2)),
+    ]
 
-    @testset "slerp" begin
-        p = SVector(0.0, 0.0, 1.0)
-        pts = ManifoldMeshes.slerp(p, p, 5)
-        @test length(pts) == 1
-
-        p1 = SVector(1.0, 0.0, 0.0)
-        p2 = SVector(0.0, 0.0, 1.0)
-        pts = ManifoldMeshes.slerp(p1, p2, 3)
-        @test length(pts) == 3
-        @test isapprox(pts[1], Point3f(Float32.(p1)), atol = 1e-6)
-        @test isapprox(pts[3], Point3f(Float32.(p2)), atol = 1e-6)
-        @test isapprox(norm(pts[2]), 1.0f0, atol = 1e-6)
+    @testset "edge_segments on $name" for (name, g) in grids
+        segs = edge_segments(g; n_arc_points = 10)
+        @test length(segs) == num_edges(g)
+        for seg in segs
+            @test all(!isnan, seg)
+            @test length(seg) >= 1
+        end
     end
 
-    @testset "node_points" begin
-        pts = ManifoldMeshes.node_points(grid)
-        @test pts isa Vector{Point3f}
-        @test length(pts) == num_nodes(grid)
-        # Spot check south pole and one equatorial node
-        @test isapprox(pts[1], Point3f(0, 0, -1), atol = 1e-6)
-        eq_idx = ManifoldMeshes._node_linear_index(grid, 3, 1)
-        @test isapprox(norm(pts[eq_idx]), 1.0f0, atol = 1e-6)
+    @testset "cell_polygons on $name" for (name, g) in grids
+        polys = cell_polygons(g; n_arc_points = 10)
+        @test length(polys) == num_cells(g)
+        for poly in polys
+            @test all(!isnan, poly)
+            @test length(poly) >= 3
+            if length(poly) > 1
+                @test norm(poly[1] - poly[end]) < 1.0f-3
+            end
+        end
     end
 
-    @testset "edge_segments" begin
-        segs = ManifoldMeshes.edge_segments(grid, n_arc_points = 5)
-        @test segs isa Vector{Vector{Point3f}}
-        @test length(segs) == num_edges(grid)
-        # Spot check one non-degenerate edge
-        @test isapprox(norm(segs[7][3]), 1.0f0, atol = 1e-6)
-    end
+    @testset "cell_triangles on $name" for (name, g) in grids
+        verts, faces = cell_triangles(g)
+        n_cells_valid = count(cid -> length(cell_nodes(g, cid)) >= 3, 1:num_cells(g))
+        @test length(faces) == sum(length(cell_nodes(g, cid)) for cid in 1:num_cells(g) if length(cell_nodes(g, cid)) >= 3) * 3
+        @test all(f -> 1 <= f <= length(verts), faces)
+        @test all(!isnan, verts)
 
-    @testset "cell_polygons" begin
-        polys = ManifoldMeshes.cell_polygons(grid, n_arc_points = 5)
-        @test polys isa Vector{Vector{Point3f}}
-        @test length(polys) == num_cells(grid)
-        # Spot check one polygon is closed
-        @test isapprox(polys[3][1], polys[3][end], atol = 1e-6)
-    end
-
-    @testset "no NaN in output" begin
-        segs = ManifoldMeshes.edge_segments(grid, n_arc_points = 10)
-        polys = ManifoldMeshes.cell_polygons(grid, n_arc_points = 10)
-        # Spot check a few samples instead of all
-        @test all(!isnan, segs[1][1])
-        @test all(!isnan, polys[1][1])
+        # Spot-check: centroid should be on sphere surface
+        R = sqrt(sum(node_coordinates(g, 1) .^ 2))
+        for cid in 1:num_cells(g)
+            ns = cell_nodes(g, cid)
+            length(ns) < 3 && continue
+            # Find centroid vertex for this cell (first vertex in its block)
+            # We can't directly index without tracking offset, so verify geometrically
+            break  # one check is enough
+        end
     end
 end

--- a/test/test_visualization_data.jl
+++ b/test/test_visualization_data.jl
@@ -1,16 +1,48 @@
 using ManifoldMeshes
 using Manifolds
+using StaticArrays
 using Test
 using GeometryBasics: Point3f
 using LinearAlgebra
 
 @testset "Visualization data extraction" begin
     grids = [
-        ("LatLonGrid", LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))),
+        ("LatLonGrid",
+            LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))),
         ("CubedSphereGrid", CubedSphereGrid(n = 4)),
         ("ReducedGaussianGrid", ReducedGaussianGrid(nlat = 8)),
-        ("HEALPixGrid", HEALPixGrid(nside = 2)),
+        ("HEALPixGrid", HEALPixGrid(nside = 2))
     ]
+
+    @testset "slerp" begin
+        p = SVector(0.0, 0.0, 1.0)
+        pts = ManifoldMeshes.slerp(p, p, 5)
+        @test length(pts) == 1
+
+        p1 = SVector(1.0, 0.0, 0.0)
+        p2 = SVector(0.0, 0.0, 1.0)
+        pts = ManifoldMeshes.slerp(p1, p2, 3)
+        @test length(pts) == 3
+        @test isapprox(pts[1], Point3f(Float32.(p1)), atol = 1e-6)
+        @test isapprox(pts[3], Point3f(Float32.(p2)), atol = 1e-6)
+        @test isapprox(norm(pts[2]), 1.0f0, atol = 1e-6)
+
+        # Antipodal endpoints
+        p3 = SVector(1.0, 0.0, 0.0)
+        p4 = SVector(-1.0, 0.0, 0.0)
+        pts = ManifoldMeshes.slerp(p3, p4, 3)
+        @test length(pts) == 3
+        @test all(p -> isapprox(norm(p), 1.0f0, atol = 1e-5), pts)
+    end
+
+    @testset "node_points" begin
+        g = LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))
+        pts = ManifoldMeshes.node_points(g)
+        @test pts isa Vector{Point3f}
+        @test length(pts) == num_nodes(g)
+        @test isapprox(pts[1], Point3f(0, 0, -1), atol = 1e-6)
+        @test all(p -> isapprox(norm(p), 1.0f0, atol = 1e-5), pts)
+    end
 
     @testset "edge_segments on $name" for (name, g) in grids
         segs = edge_segments(g; n_arc_points = 10)
@@ -36,18 +68,21 @@ using LinearAlgebra
     @testset "cell_triangles on $name" for (name, g) in grids
         verts, faces = cell_triangles(g)
         n_cells_valid = count(cid -> length(cell_nodes(g, cid)) >= 3, 1:num_cells(g))
-        @test length(faces) == sum(length(cell_nodes(g, cid)) for cid in 1:num_cells(g) if length(cell_nodes(g, cid)) >= 3) * 3
+        @test length(faces) ==
+              sum(length(cell_nodes(g, cid))
+        for cid in 1:num_cells(g) if length(cell_nodes(g, cid)) >= 3) * 3
         @test all(f -> 1 <= f <= length(verts), faces)
         @test all(!isnan, verts)
 
-        # Spot-check: centroid should be on sphere surface
+        # Spot-check: centroids should lie on the sphere surface
         R = sqrt(sum(node_coordinates(g, 1) .^ 2))
+        offset = 0
         for cid in 1:num_cells(g)
             ns = cell_nodes(g, cid)
-            length(ns) < 3 && continue
-            # Find centroid vertex for this cell (first vertex in its block)
-            # We can't directly index without tracking offset, so verify geometrically
-            break  # one check is enough
+            K = length(ns)
+            K < 3 && continue
+            @test isapprox(norm(verts[offset + 1]), R, atol = 1.0f-4)
+            offset += K + 1
         end
     end
 end

--- a/test/test_visualization_smoke.jl
+++ b/test/test_visualization_smoke.jl
@@ -5,27 +5,34 @@ using Test
 using CairoMakie
 
 @testset "Visualization smoke tests" begin
-    grid = LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))
+    grids = [
+        ("LatLonGrid", LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))),
+        ("CubedSphereGrid", CubedSphereGrid(n = 4)),
+        ("ReducedGaussianGrid", ReducedGaussianGrid(nlat = 8)),
+        ("HEALPixGrid", HEALPixGrid(nside = 2)),
+    ]
 
-    @testset "plot_mesh 3D wireframe" begin
-        fig = plot_mesh(grid; show_nodes = false, show_edges = true, figsize = (400, 400))
-        @test fig isa Figure
-        save("test_mesh_3d.png", fig)
-        @test isfile("test_mesh_3d.png")
-        rm("test_mesh_3d.png")
-    end
+    for (name, grid) in grids
+        @testset "plot_mesh 3D wireframe on $name" begin
+            fig = plot_mesh(grid; show_nodes = false, show_edges = true, figsize = (400, 400))
+            @test fig isa Figure
+            save("test_mesh_$(name).png", fig)
+            @test isfile("test_mesh_$(name).png")
+            rm("test_mesh_$(name).png")
+        end
 
-    @testset "plot_mesh_filled 3D" begin
-        fig = plot_mesh_filled(grid; show_edges = true, figsize = (400, 400))
-        @test fig isa Figure
-        save("test_filled_3d.png", fig)
-        @test isfile("test_filled_3d.png")
-        rm("test_filled_3d.png")
+        @testset "plot_mesh_filled 3D on $name" begin
+            fig = plot_mesh_filled(grid; show_edges = true, figsize = (400, 400))
+            @test fig isa Figure
+            save("test_filled_$(name).png", fig)
+            @test isfile("test_filled_$(name).png")
+            rm("test_filled_$(name).png")
+        end
     end
 
     @testset "color_by function" begin
-        fig = plot_mesh_filled(grid; color_by = i -> (i % 2 == 0 ? :red : :blue), figsize = (
-            400, 400))
+        grid = LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))
+        fig = plot_mesh_filled(grid; color_by = i -> (i % 2 == 0 ? :red : :blue), figsize = (400, 400))
         @test fig isa Figure
     end
 end

--- a/test/test_visualization_smoke.jl
+++ b/test/test_visualization_smoke.jl
@@ -6,15 +6,17 @@ using CairoMakie
 
 @testset "Visualization smoke tests" begin
     grids = [
-        ("LatLonGrid", LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))),
+        ("LatLonGrid",
+            LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))),
         ("CubedSphereGrid", CubedSphereGrid(n = 4)),
         ("ReducedGaussianGrid", ReducedGaussianGrid(nlat = 8)),
-        ("HEALPixGrid", HEALPixGrid(nside = 2)),
+        ("HEALPixGrid", HEALPixGrid(nside = 2))
     ]
 
     for (name, grid) in grids
         @testset "plot_mesh 3D wireframe on $name" begin
-            fig = plot_mesh(grid; show_nodes = false, show_edges = true, figsize = (400, 400))
+            fig = plot_mesh(grid; show_nodes = false, show_edges = true, figsize = (
+                400, 400))
             @test fig isa Figure
             save("test_mesh_$(name).png", fig)
             @test isfile("test_mesh_$(name).png")
@@ -32,7 +34,8 @@ using CairoMakie
 
     @testset "color_by function" begin
         grid = LatLonGrid(lat_edges = collect(-90.0:30.0:90.0), lon_edges = collect(0.0:60.0:360.0))
-        fig = plot_mesh_filled(grid; color_by = i -> (i % 2 == 0 ? :red : :blue), figsize = (400, 400))
+        fig = plot_mesh_filled(grid; color_by = i -> (i % 2 == 0 ? :red : :blue), figsize = (
+            400, 400))
         @test fig isa Figure
     end
 end


### PR DESCRIPTION
## Summary

This PR refactors the visualization subsystem to work generically across all 4 S² grid types (LatLonGrid, CubedSphereGrid, ReducedGaussianGrid, HEALPixGrid) and improves rendering performance.

### Key Changes

- **Generic edge/polygon derivation** (mesh_data.jl): Removed hardcoded quad-cell assumptions. edge_segments() and cell_polygons() now derive edges from consecutive cell_nodes boundary order, making visualization correct for any grid topology.
- **New cell_triangles() function**: Decomposes each cell into K triangles fanning from the sphere-projected centroid. Returns shared-vertex (vertices, faces) suitable for GeometryBasics.Mesh.
- **Batched rendering** (plotting.jl): Edge wireframes use a single NaN-separated lines!() call; filled meshes use a single mesh!(verts, faces) call with per-vertex coloring.
- **Extended test coverage**: Both test files now cover all 4 grid types. Restored slerp and node_points unit tests.
- **New example script** (examples/grids_visualization.jl): Standalone script producing a 4×2 comparison figure.
- **Code review fixes**: Explicit imports, hardened color array type, improved documentation, completed assertions, applied JuliaFormatter.

### Test Results

All 2657 tests pass (including Aqua). All CI checks green.

### Commits

- 0c8e150 refactor(visualization): derive edges and polygons from cell_nodes boundary order
- 9e8005d feat(visualization): add cell_triangles with sphere-projected centroid and K+1 vertex sharing
- 1219a41 refactor(visualization): batch edge rendering in plot_mesh with NaN-separated lines
- 544529c refactor(visualization): batch fill rendering in plot_mesh_filled with mesh!(verts, faces)
- f14c181 test(visualization): extend data tests to all grid types, add cell_triangles tests
- a373c13 test(visualization): extend smoke tests to all 4 grid types
- 3b4def1 feat: add grids_visualization example script
- d766b7e refactor(examples): improve visualization aesthetics
- b21bc0c fix(visualization): address code review issues and format